### PR TITLE
Ensure consistent heading elements by changing h1 to h2

### DIFF
--- a/src/app/components/about.tsx
+++ b/src/app/components/about.tsx
@@ -9,9 +9,9 @@ export default function About() {
 			>
 				{/* Container */}
 				<div className="lg:flex lg:flex-col lg:w-1/2 justify-center lg:justify-start">
-					<h1 className="lg:flex items-center text-[36px] lg:text-[40px] lg:text-left font-bold text-[#F7F9FC] mb-[20px]">
+					<h2 className="lg:flex items-center text-[36px] lg:text-[40px] lg:text-left font-bold text-[#F7F9FC] mb-[20px]">
 						About me
-					</h1>
+					</h2>
 					<div className="flex gap-[10px]">
 						<p className="font-bold text-[128px] text-[#e0fa8c] -mt-10">{`"`}</p>
 						<p className="lg:text-[32px] shadow-text">

--- a/src/app/components/contact.tsx
+++ b/src/app/components/contact.tsx
@@ -11,9 +11,9 @@ export default function Contact() {
 				<div className="w-full max-w-[1200px] mx-auto flex flex-col px-[20px] py-[50px] lg:p-[20px]">
 					{/* title */}
 					<div className="mb-[20px] flex justify-center">
-						<h1 className="flex items-center text-[36px] lg:text-[40px] font-bold">
+						<h2 className="flex items-center text-[36px] lg:text-[40px] font-bold">
 							Contact Me
-						</h1>
+						</h2>
 					</div>
 					{/* main contact details */}
 					<div className="flex flex-col lg:flex-row gap-[20px] lg:justify-between py-[20px] font-normal">

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -6,9 +6,9 @@ export default function Header() {
 		<div className="flex justify-center w-full lg:max-h-[96px] top-0">
 			<header className="w-full lg:max-w-[1280px] h-full lg:p-[28px] flex flex-col lg:flex-row justify-between items-center">
 				<div>
-					<h1 className="text-[36px] font-bold bg-clip-text text-transparent bg-gradient-to-bl from-amber-500 from-10% to-teal-500 to-90%">
+					<h2 className="text-[36px] font-bold bg-clip-text text-transparent bg-gradient-to-bl from-amber-500 from-10% to-teal-500 to-90%">
 						HARBs
-					</h1>
+					</h2>
 				</div>
 
 				<div className="flex items-center gap-6 lg:gap-[28px]">

--- a/src/app/components/scroll.tsx
+++ b/src/app/components/scroll.tsx
@@ -5,7 +5,7 @@ export default function ScrollPage() {
   return (
     <div className="space-y-40 p-10">
       <section className="h-screen flex items-center justify-center">
-        <h1 className="text-5xl font-bold">Scroll Down 👇</h1>
+        <h2 className="text-5xl font-bold">Scroll Down 👇</h2>
       </section>
 
       {/* Fade In Section */}

--- a/src/app/components/services.tsx
+++ b/src/app/components/services.tsx
@@ -6,15 +6,15 @@ export default function Services() {
 		<>
 			<div className="w-full max-w-7xl flex justify-center px-[20px] py-[50px] lg:px-[110px] lg: place-self-center gap-[20px]">
 				<div className="w-full">
-					<h1 className="place-self-end text-[36px] lg:text-[40px] lg:text-left font-bold text-[#F7F9FC] mb-[20px]">
+					<h2 className="place-self-end text-[36px] lg:text-[40px] lg:text-left font-bold text-[#F7F9FC] mb-[20px]">
 						What I do
-					</h1>
+					</h2>
 					<div className="flex flex-col lg:flex-row gap-[10px] lg:gap-[20px]">
 						<GlassPane>
 							<div className="p-[16px]">
-								<h1 className="text-[24px] text-center lg:text-[28px] font-bold text-[#F7F9FC] mb-[16px]">
+								<h2 className="text-[24px] text-center lg:text-[28px] font-bold text-[#F7F9FC] mb-[16px]">
 									Software Development
-								</h1>
+								</h2>
 								<p>
 									{`If you need a developer to handle the research and development of your website, I have the skills and experience to help.`}
 								</p>
@@ -22,9 +22,9 @@ export default function Services() {
 						</GlassPane>
 						<GlassPane>
 							<div className="p-[16px]"> 
-								<h1 className="text-[24px] text-center lg:text-[28px] font-bold text-[#F7F9FC] mb-[20px]">
+								<h2 className="text-[24px] text-center lg:text-[28px] font-bold text-[#F7F9FC] mb-[20px]">
 									UI/UX Design
-								</h1>
+								</h2>
 								<p>
 									{`An effective UI/UX grabs attention and communicates a clear message. I ensure the design is both innovative and clean.`}
 								</p>

--- a/src/app/loop/page.tsx
+++ b/src/app/loop/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
 					key={`sub-${i}-${j}`}
 					className="w-full flex items-center p-2"
 				>
-					<h1 className="text-xl font-semibold">#</h1>
+					<h2 className="text-xl font-semibold">#</h2>
 				</Glasspane>
 			);
 		}
@@ -22,7 +22,7 @@ export default function Home() {
 				key={`group-${i}`}
 				className="w-full grid grid-cols-10 p-2 gap-2"
 			>
-				<h1 className="text-2xl font-bold col-span-1">{i}</h1>
+				<h2 className="text-2xl font-bold col-span-1">{i}</h2>
 				<div className="grid grid-cols-8 gap-1 col-span-9">{subItems}</div>
 			</Glasspane>
 		);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,9 +131,9 @@ export default function Home() {
 					<div className=" bg-gray-900 scroll-mt-16" id="contact">
 						{/* CONTACT ME */}
 						<div className="py-[36px] px-[12px] flex flex-col gap-[12px] text-white max-w-6xl mx-auto">
-							<h1 className="text-[48px] text-center md:text-[128px]">
+							<h2 className="text-[48px] text-center md:text-[128px]">
 								Contact me
-							</h1>
+							</h2>
 							<div className="py-[16px] flex gap-[36px] justify-center">
 								<a
 									href="https://www.linkedin.com/in/harvey-dangel-a4b09b355/"

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -22,7 +22,7 @@ export default async function ProjectDetail({
 		<>
 			<div className="min-h-screen w-full max-w-[1280px] py-12 px-4 sm:px-6 lg:px-8 place-self-center">
 				<div className="max-w-4xl mx-auto">
-					<h1 className="text-3xl font-bold mb-6">{project.title}</h1>
+					<h2 className="text-3xl font-bold mb-6">{project.title}</h2>
 					<div className="mb-8">
 						<Image
 							src={project.imageUrl}


### PR DESCRIPTION
## Change heading elements from h1 to h2 for consistency

### Summary

This pull request updates heading elements across the application by replacing h1 tags with h2 tags to ensure a consistent heading hierarchy and improve semantic structure.

### Changes Made

* Replaced all h1 elements with h2 where appropriate
* Ensured consistent usage of heading levels across pages and components
* Maintained visual styling to avoid unintended UI changes

### Why is it needed?

Using multiple h1 elements across different sections can create inconsistency in the document structure and negatively impact accessibility and SEO. A proper heading hierarchy helps screen readers interpret content correctly and improves overall readability. By standardizing headings to h2, we ensure a more structured and maintainable layout while aligning with best practices.

### Notes

* No visual regressions expected since styling remains unchanged
* Future enhancements can introduce a clear heading hierarchy strategy if needed
